### PR TITLE
Yet another encoding folder update.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,6 +17,7 @@
 - [Scenefiltering](encoding/scenefiltering.md)
 - [Masking, Limiting, and Related Functions](encoding/masking-limiting-etc.md)
 - [Resampling](encoding/resampling.md)
+- [Codecs](encoding/video-encoding.md)
 
 
 ## Typesetting

--- a/encoding/preparation.md
+++ b/encoding/preparation.md
@@ -214,6 +214,13 @@ as of [24 Dec 2017][unification-commit],
 meaning the releases with -10b can be ignored)
 You can also build it locally from [the public repository][x264vlan-git].
 
+It used to be that different versions,
+namely kmod and tmod,
+were required for certain exclusive encoding features
+such as "aq-mode 3".
+However, all relevant features have been included in the upstream
+x264 builds since August 2018.
+
 A newer, more efficient alternative is x265.
 It is still in active development
 and aims for 20-50% lower bitrates with the same quality as x264.

--- a/encoding/preparation.md
+++ b/encoding/preparation.md
@@ -204,12 +204,13 @@ and which ones you want to use.
 
 The codec used most commonly is x264,
 an implementation of the h.264 standard.
-The most recent builds can be found [here][x264vlan].
+The most recent builds can be found on [VideoLAN's site][x264vlan].
 Pick the most recent build for your operating system.
 At the time of writing this,
 win64's recent build is `x264-r2935-545de2f.exe`
 from 25-Sep-2018.
-(Notice: the 10-bit binaries are no longer separate from the 8-bit,
+(Notice: the 10-bit binaries are no longer separate from the 8-bit
+as of [24 Dec 2017][unification-commit],
 meaning the releases with -10b can be ignored)
 You can also build it locally from [the public repository][x264vlan-git].
 
@@ -237,6 +238,7 @@ such as Intel's [SVT-AV1][] will also not be included.
 [Daala]: https://xiph.org/daala/
 [AV-1]: https://aomediacodec.github.io/av1-spec/
 [SVT-AV1]: https://github.com/OpenVisualCloud/SVT-AV1
+[unification-commit]: https://git.videolan.org/?p=x264.git;a=commit;h=71ed44c7312438fac7c5c5301e45522e57127db4
 
 
 ## Audio Codecs

--- a/encoding/preparation.md
+++ b/encoding/preparation.md
@@ -204,23 +204,14 @@ and which ones you want to use.
 
 The codec used most commonly is x264,
 an implementation of the h.264 standard.
-There are multiple versions available
-(kmod and tmod being the most popular ones),
-but they only differ slightly
-(mainly cosmetic patches and some obscure parameters
-that you will probably never use),
-and no version is objectively better than any other.
-x264 can encode in 8 or 10 bit color depth.
-We will explain the meaning of these at a later time.
-For now, they are just relevant for choosing the right binary.
-All modifications come in two versions each,
-one for 8 bit and one for 10 bit[^2].
-Most fansub group nowadays use 10 bit,
-so you should download that
-unless your group leader or encode mentor told you otherwise.
-
-- [Download kmod](http://komisar.gin.by/)
-- [Download tmod](https://github.com/jpsdr/x264/releases)
+The most recent builds can be found [here][x264vlan].
+Pick the most recent build for your operating system.
+At the time of writing this,
+win64's recent build is `x264-r2935-545de2f.exe`
+from 25-Sep-2018.
+(Notice: the 10-bit binaries are no longer separate from the 8-bit,
+meaning the releases with -10b can be ignored)
+You can also build it locally from [the public repository][x264vlan-git].
 
 A newer, more efficient alternative is x265.
 It is still in active development
@@ -241,6 +232,8 @@ The same is true for experimental codecs like [Daala][] and [AV-1][].
 Encoders made for distributed server encoding,
 such as Intel's [SVT-AV1][] will also not be included.
 
+[x264vlan]: https://download.videolan.org/pub/videolan/x264/binaries/
+[x264vlan-git]: https://git.videolan.org/?p=x264.git;a=summary
 [Daala]: https://xiph.org/daala/
 [AV-1]: https://aomediacodec.github.io/av1-spec/
 [SVT-AV1]: https://github.com/OpenVisualCloud/SVT-AV1
@@ -295,5 +288,3 @@ Just extract it somewhere.
 ---
 
 [^1]: It should be noted that the author strongly disagrees with this sentiment. The two have a lot in common, and any capable Avisynth encoder could reach a similar leven in Vapoursynth within a few months, maybe even weeks. At least I'm honest, okay?
-
-[^2]: https://github.com/Irrational-Encoding-Wizardry/guide.encode.moe/issues/1

--- a/encoding/preparation.md
+++ b/encoding/preparation.md
@@ -237,13 +237,13 @@ so ask your group leader before picking this codec.
 Other codecs, such as VP9,
 are generally not used for fansubbing,
 so they are not listed here.
-The same is true for unreleased codecs like [Daala][] and [AV-1][].
+The same is true for experimental codecs like [Daala][] and [AV-1][].
 Encoders made for distributed server encoding,
 such as Intel's [SVT-AV1][] will also not be included.
 
 [Daala]: https://xiph.org/daala/
 [AV-1]: https://aomediacodec.github.io/av1-spec/
-[STV-AV1]: https://github.com/OpenVisualCloud/SVT-AV1
+[SVT-AV1]: https://github.com/OpenVisualCloud/SVT-AV1
 
 
 ## Audio Codecs

--- a/encoding/preparation.md
+++ b/encoding/preparation.md
@@ -290,7 +290,7 @@ Just like the codecs,
 you don't have to install it.
 Just extract it somewhere.
 
-[ffpeg-zeranoe]: http://ffmpeg.zeranoe.com/builds/ "FFmpeg"
+[ffmpeg-zeranoe]: http://ffmpeg.zeranoe.com/builds/ "FFmpeg"
 
 ---
 

--- a/encoding/video-artifacts.md
+++ b/encoding/video-artifacts.md
@@ -232,17 +232,10 @@ Noise
 
 ---
 
-[^1]: At least, in digital anime.
-Actual grain is different
-but you most likely aren't encoding shows from the 90s
-so who cares.
+[^1]: At least, in digital anime. Actual grain is different but you most likely aren't encoding shows from the 90s so who cares.
 
 [^2]: Urban, J. (2017, February 16). Understanding Video Compression Artifacts. Retrieved from http://blog.biamp.com/understanding-video-compression-artifacts/
 
-[^3]: Blocking may also occur for other reasons
-other than compression data loss.
-[Image re-construction with padding][waifu2x238] can cause
-very similar looking effects, although this is irrelevant for
-fansubbing source videos.
+[^3]: Blocking may also occur for other reasons other than compression data loss. [Image re-construction with padding][waifu2x238] can cause very similar looking effects, although this is irrelevant for fansubbing source videos.
 
 [waifu2x238]: https://github.com/nagadomi/waifu2x/issues/238

--- a/encoding/video-artifacts.md
+++ b/encoding/video-artifacts.md
@@ -71,7 +71,9 @@ you will likely come across something like this:
 
 ![Blocky Compression](images/blocky2.png)
 
-![Blocky Exaggeration](images/blocky1.jpg)\(Urban, 2017\)
+![Blocky Exaggeration](images/blocky1.jpg)
+
+<p align="center">\(Urban, 2017\)</p>
 
 From Biamp's Blog[^2]:
 "Blocking is known by several names – including tiling,
@@ -180,7 +182,9 @@ edge enhancement artifacts,
 overshoot,
 or actual ring-like ringing caused by the Gibbs phenomenon.
 
-![Mosquito Noise](images/mosquito1.png)\(Urban, 2017\)
+![Mosquito Noise](images/mosquito1.png)
+
+<p align="center">\(Urban, 2017\)</p>
 
 In Blu-ray encodes,
 the only ringing you’ll be likely to see is

--- a/encoding/video-encoding.md
+++ b/encoding/video-encoding.md
@@ -2,3 +2,9 @@
 
 <TODO - mention codecs, new and old>
 <TODO - this whole page>
+
+This page is under construction.
+To help finish this page,
+you can contribute by clicking
+<kbd><i class="fa fa-edit"></i> EDIT THIS PAGE</kbd>
+at the top left.

--- a/overview/roles.md
+++ b/overview/roles.md
@@ -216,14 +216,11 @@ and can be highly programming-oriented.
 
 ***
 
-[^1]: *TODO - sources for AviSynth and VapourSynth builds
-relevant to fansubbing.*
+[^1]: *TODO - sources for AviSynth and VapourSynth builds relevant to fansubbing.*
 
-[^2]: Further reading on the x264 and x265 libraries can be found
-[here][reddit-x264-x265].
+[^2]: Further reading on the x264 and x265 libraries can be found [here][reddit-x264-x265].
 
-[^3]: Comparisons of various audio codecs can be found
-[here][wikipedia-audio].
+[^3]: Comparisons of various audio codecs can be found [here][wikipedia-audio].
 
 [reddit-x264-x265]: https://www.reddit.com/r/anime/comments/8ktmvu/nerdpost_how_fansubbers_make_your_anime_look/
 [wikipedia-audio]: https://en.wikipedia.org/wiki/Comparison_of_audio_coding_formats


### PR DESCRIPTION
Notable changes:
- 7d1daf7 resolves #1 by updating the information regarding x264 codec (thanks kageru!)

Fixes:
- b8c98b3 sadly footnotes refuse to work with semantic linefeeds
- facbf0b + c4587c1  ffmpeg and SVT link now work
- 96566fb + c4e83e4 prevent gitbook from attempting to download a blank .md file

Formatting:
- 2e5e5a2 improved alignment for when images have a (reference)