### PR TITLE
CSS visual update

### DIFF
--- a/styles/website.css
+++ b/styles/website.css
@@ -484,3 +484,17 @@ img {
     position: relative;
     text-decoration: none!important;
 }
+
+/* Footnote formatting */
+.markdown-section blockquote{
+    border-left: 4px solid #D8D8D8;
+    color: rgba(0,0,0,0.66);
+}
+.book.color-theme-1 .markdown-section blockquote {
+    border-left: 4px solid #957C76 !important;
+    color: rgba(102,58,15,0.66);
+}
+.book.color-theme-2 .markdown-section blockquote {
+    border-left: 4px solid #373b4e;
+    color: rgba(255,255,255,0.66);
+}

--- a/styles/website.css
+++ b/styles/website.css
@@ -248,8 +248,10 @@ pre.term > button.t-copy, pre.term > i.t-copy {
     background-color: #BE9470;
 }
 .book.color-theme-1 .dropdown-menu .buttons{
-    color: #F2F2DA;
     border-color: #A68162;
+}
+.book.color-theme-1 .dropdown-menu .buttons .button {
+    color: #F2F2DA;
 }
 .book.color-theme-1 .dropdown-menu .buttons .button:hover {
     color: #663A0F;


### PR DESCRIPTION
- e1c72e3 changes back the button menu divider color 

![image](https://user-images.githubusercontent.com/10972040/53166699-0d909a80-35a4-11e9-8314-2ff7466d88cb.png)
--->>
![image](https://user-images.githubusercontent.com/10972040/53166666-fe115180-35a3-11e9-8fc5-a29622f5ad09.png)

- 6caee01 some footnote coloring

![image](https://user-images.githubusercontent.com/10972040/53166767-3749c180-35a4-11e9-952b-5139efa44d07.png)
--->>
![image](https://user-images.githubusercontent.com/10972040/53166782-429ced00-35a4-11e9-8251-117a21086112.png)


