### PR TITLE
Reemphasize that encoding lossy to lossless is useless

### DIFF
--- a/encoding/preparation.md
+++ b/encoding/preparation.md
@@ -304,9 +304,19 @@ adding it to the system PATH is recommeded.
 When working with WEB and TV sources,
 you will most likely have only lossy audio available.
 The most common codecs here are AC-3, E-AC-3 and AAC.
-Lossily compressed files should generally
-not be reencoded—the proper way to handle them
+**Lossily compressed audio
+should generally not be reencoded**—the proper way to handle them
 is to remux (i.e. copy) them to the final file.
+Reencoding lossy audio into a different lossy audio codec
+cannot improve the audio quality
+for barely improved compression
+(in relation and assuming a lower bitrate),
+while encoding into a lossless audio codec
+is just wasting bandwidth.
+Your source file will always have the most data available
+and using a lossless codec for that
+can not generate data lost from the previous compression
+from thin air.
 
 [ffmpeg]: https://www.ffmpeg.org/download.html
 
@@ -370,6 +380,10 @@ be audible anyway.
 And they both have a point.
 
 So, do some ABX testing and decide for yourself.
+
+However, remember that you should not reencode
+lossily compressed audio
+into a lossless codec.
 
 
 ## MKVToolNix


### PR DESCRIPTION
I didn't like the wording suggested in #19 and @rokweom rightfully mentioned that we'd be repeating ourselves, so I propose a different solution that clarifies why you shouldn't reencode in the initial section and later references it for clarity.