### PR TITLE
Add new CSS rules for image scaling

### DIFF
--- a/styles/website.css
+++ b/styles/website.css
@@ -508,16 +508,42 @@ figcaption {
     margin-top: 1px;
 }
 
-/* image hovering shadow */
+/* image hovering shadow/zoom */
 img:hover {
-    box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
+    position: relative;
+    z-index: 100;
+    /* will dim entire display except picture and sidebar */
+    /* box-shadow: 0px 0px 10000px 10000px rgba(0, 0, 0, 0.4);*/
+    box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.8);
+    max-width: 100% !important;
+    transition-delay: 300ms;
+    transition-duration: 300ms;
+    transition-timing-function: ease-in;
 }
 
 /* centering images with CSS instead of in-line HTML */
+/* also reverses hovering shadow/zoom transition */
 img {
+    position: relative;
     display: block;
     margin-left: auto;
     margin-right: auto;
+    transition-delay: 50ms;
+    transition-duration: 150ms;
+    transition-timing-function: ease-out;
+}
+
+/* scaling down images to a sensible size based on .page-inner */
+.markdown-section img {
+    max-width: 70%;
+}
+@media (max-width: 1240px) {
+    .markdown-section img {
+        max-width: 100%
+    }
+    img:hover {
+        box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0);
+    }
 }
 
 /* Glossary terms formatting */


### PR DESCRIPTION
- on a full width display, images will be scaled down to stop taking up so much space vertically
  - when hovered over, will return to 100% (of the .page-inner, so actually just <=90em)
  - if the image width is already below 70% of <=90em, it won't be scaled and hover will just add a small shadow behind

Animation preview: https://jsfiddle.net/wk6drxp5/

Currently:
![current](https://user-images.githubusercontent.com/10972040/64186692-435ce880-ce3d-11e9-9eb1-b1c5e3c79866.png)

---

After:
![future](https://user-images.githubusercontent.com/10972040/64186806-730bf080-ce3d-11e9-8a71-269e1f709f25.png)
`:hover`
![image](https://user-images.githubusercontent.com/10972040/64186850-8b7c0b00-ce3d-11e9-88e9-78d78d8ad159.png)

---

also adds a test line for darkening entire website behind the picture when hovered over, maybe will be useful for something else
