### PR TITLE
Fix bitrate calculation

### DIFF
--- a/encoding/codecs/x264.md
+++ b/encoding/codecs/x264.md
@@ -196,7 +196,7 @@ as the only argument without a `--` flag before it.
 
 For the next example,
 let's say we want to make sure our encode
-fits onto a single 4.7GB DVD.
+fits onto a single 4.7GB DVD[^1].
 How would we do that in x264?
 
 First, we'll need to figure out
@@ -216,9 +216,9 @@ This means we'll need to know a couple of things:
 
 $$
 \begin{aligned}
-4.7\:\mathrm{GiB}\times \frac{1024\:\mathrm{MiB}}{\mathrm{GiB}} &= 4812.8\:\mathrm{MiB}\\\\
-4812.8\:\mathrm{MiB}\times \frac{1024\:\mathrm{KiB}}{\mathrm{MiB}} &\approx 4,928,300\:\mathrm{KiB}\\\\
-4,928,300\:\mathrm{KiB}\times \frac{8\:\mathrm{Kbits}}{\mathrm{KiB}} &\approx 39,426,000\:\mathrm{Kbits}
+4.7\:\mathrm{GB}\times \frac{1000\:\mathrm{MB}}{\mathrm{GB}} &= 4700\:\mathrm{MB}\\\\
+4700\:\mathrm{MB}\times \frac{1000\:\mathrm{KB}}{\mathrm{MB}} &= 4,700,000\:\mathrm{KB}\\\\
+4,700,000\:\mathrm{KB}\times \frac{8\:\mathrm{Kbits}}{\mathrm{KB}} &= 37,600,000\:\mathrm{Kbits}
 \end{aligned}
 $$
 
@@ -226,13 +226,21 @@ Now we divide the kilobit size we calculated by our video length,
 to find our kilobit per second target bitrate:
 
 $$
-39,426,000\:\mathrm{Kbits}\div 7200\:\mathrm{seconds} \approx 5475\:\mathrm{Kbps}
+37,600,000\:\mathrm{Kbits}\div 7200\:\mathrm{seconds} \approx 5222\:\mathrm{Kbps}
 $$
+
+There is also a [python script][brate_fsize] that can handle this calculation for us:
+
+```py
+>>> from bitrate_filesize import *
+>>> find_bitrate('4.7 GB', seconds=7200)
+bitrate should be 5,222 kbps
+```
 
 And here's how we could add that to our x264 command:
 
 ```
-vspipe --y4m myvideo.vpy - | x264 --demuxer y4m --preset veryfast --bitrate 5475 -o x264output.mkv -
+vspipe --y4m myvideo.vpy - | x264 --demuxer y4m --preset veryfast --bitrate 5222 -o x264output.mkv -
 ```
 
 The `--bitrate` option, by itself,
@@ -241,6 +249,8 @@ In other words, the encoder will still give more bits
 to sections of the video that have more detail or motion,
 but the average bitrate of the video
 will be close to what we requested.
+
+[brate_fsize]: https://gist.githubusercontent.com/OrangeChannel/816a87cf760d9be19bde18db8818d4bc/raw/bitrate_filesize.py
 
 
 ### Example 3: 2-Pass Encoding
@@ -268,14 +278,14 @@ if you need to target a certain bitrate.
 Here's how we would run our first pass:
 
 ```
-vspipe --y4m myvideo.vpy - | x264 --demuxer y4m --preset veryfast --pass 1 --bitrate 5475 -o x264output.mkv -
+vspipe --y4m myvideo.vpy - | x264 --demuxer y4m --preset veryfast --pass 1 --bitrate 5222 -o x264output.mkv -
 ```
 
 This creates a stats file in our current directory,
 which x264 will use in the second pass:
 
 ```
-vspipe --y4m myvideo.vpy - | x264 --demuxer y4m --preset veryfast --pass 2 --bitrate 5475 -o x264output.mkv -
+vspipe --y4m myvideo.vpy - | x264 --demuxer y4m --preset veryfast --pass 2 --bitrate 5222 -o x264output.mkv -
 ```
 
 You'll notice all we had to change was `--pass 1` to `--pass 2`. Simple!
@@ -309,3 +319,7 @@ Here is a summary of when to use each encoding mode:
 ## Advanced Configuration
 
 Coming Soon
+
+---
+
+[^1]: Source: <http://www.mpeg.org/MPEG/DVD/Book_A/Specs.html>

--- a/encoding/codecs/x264.md
+++ b/encoding/codecs/x264.md
@@ -218,7 +218,7 @@ $$
 \begin{aligned}
 4.7\:\mathrm{GB}\times \frac{1000\:\mathrm{MB}}{\mathrm{GB}} &= 4700\:\mathrm{MB}\\\\
 4700\:\mathrm{MB}\times \frac{1000\:\mathrm{KB}}{\mathrm{MB}} &= 4,700,000\:\mathrm{KB}\\\\
-4,700,000\:\mathrm{KB}\times \frac{8\:\mathrm{Kbits}}{\mathrm{KB}} &= 37,600,000\:\mathrm{Kbits}
+4,700,000\:\mathrm{KB}\times \frac{8\:\mathrm{Kbit}}{\mathrm{KB}} &= 37,600,000\:\mathrm{Kbit}
 \end{aligned}
 $$
 
@@ -226,7 +226,7 @@ Now we divide the kilobit size we calculated by our video length,
 to find our kilobit per second target bitrate:
 
 $$
-37,600,000\:\mathrm{Kbits}\div 7200\:\mathrm{seconds} \approx 5222\:\mathrm{Kbps}
+37,600,000\:\mathrm{Kbit}\div 7200\:\mathrm{seconds} \approx 5222\:\mathrm{Kbps}
 $$
 
 There is also a [python script][brate_fsize] that can handle this calculation for us:


### PR DESCRIPTION
If we were to use GiB instead, the answer still wouldn't have been 5475 kbps as 1Kib != 1Kb: 1Kib is 1.024Kb, so the answer should've been ~5607 kbps.
```py
>>> find_filesize(5475, seconds=7200)
estimated filesize is 4.59 GiB or 4.93 GB
>>> find_filesize(5607, seconds=7200)
estimated filesize is 4.70 GiB or 5.05 GB
```
I checked that the DVD size is specified in decimal GB and listed the source.

Added the python script (that I initially wrote for the ordered-chapters math) so nobody has to do this manually anymore.


