### PR TITLE
x265: update mods and vspipe call

### DIFF
--- a/src/encoding/codecs/x265.md
+++ b/src/encoding/codecs/x265.md
@@ -39,9 +39,8 @@ It's worth mentioning
 that there are several modified versions of *x265*
 specifically improved for animation encoding.
 
-- [Asuna](https://github.com/msg7086/x265-Yuuki-Asuna/tree/Asuna)
-- [Yuuki](https://github.com/msg7086/x265-Yuuki-Asuna/tree/Yuuki)
-- [AmusementClub](https://github.com/AmusementClub/x265)
+- [aMod](https://github.com/DJATOM/x265-aMod)
+- [jpsdr](https://github.com/jpsdr/x265/tree/x265_mod)
 
 These modifications may include
 some custom features and performance optimizations.
@@ -91,13 +90,13 @@ where your VapourSynth script lives.
 Let's use the following command:
 
 ```sh
-vspipe --y4m myvideo.vpy - | x265 --y4m --profile main10 --preset veryfast --tune animation --crf 20 -o x265output.mkv -
+vspipe -c y4m myvideo.vpy - | x265 --y4m --profile main10 --preset veryfast --tune animation --crf 20 -o x265output.mkv -
 ```
 
 We'll run through what each of these options means:
 
 
-#### `vspipe --y4m myvideo.vpy -`
+#### `vspipe -c y4m myvideo.vpy -`
 
 This portion loads your VapourSynth script
 and pipes it to stdout,
@@ -248,7 +247,7 @@ is listed in [the *x264* documentation](./x264.md#example-2-targeted-file-size).
 And here's how we could add that to our *x265* command:
 
 ```sh
-vspipe --y4m myvideo.vpy - | x265 --y4m --preset veryfast --bitrate 5222 -o x265output.mkv -
+vspipe -c y4m myvideo.vpy - | x265 --y4m --preset veryfast --bitrate 5222 -o x265output.mkv -
 ```
 
 The `--bitrate` option, by itself,
@@ -284,14 +283,14 @@ if you need to target a certain bitrate.
 Here's how we would run our first pass:
 
 ```sh
-vspipe --y4m myvideo.vpy - | x265 --y4m --preset veryfast --pass 1 --bitrate 5222 -o x265output.mkv -
+vspipe -c y4m myvideo.vpy - | x265 --y4m --preset veryfast --pass 1 --bitrate 5222 -o x265output.mkv -
 ```
 
 This creates a stats file in our current directory,
 which *x265* will use in the second pass:
 
 ```sh
-vspipe --y4m myvideo.vpy - | x265 --y4m --preset veryfast --pass 2 --bitrate 5222 -o x265output.mkv -
+vspipe -c y4m myvideo.vpy - | x265 --y4m --preset veryfast --pass 2 --bitrate 5222 -o x265output.mkv -
 ```
 
 You'll notice all we had to change was `--pass 1` to `--pass 2`.


### PR DESCRIPTION
vspipe --y4m is deprecated (https://github.com/vapoursynth/vapoursynth/blob/master/src/vspipe/vspipe.cpp#L702)
the previously linked mods have blocking issues: https://slow.pics/c/2ZU6BUOW added links to mods that should be safe