### PR TITLE
Fix broken links.

### DIFF
--- a/src/encoding/basics-and-workflow.md
+++ b/src/encoding/basics-and-workflow.md
@@ -168,7 +168,7 @@ ffmpeg -i "input.dtshd" -c:a pcm_s24le -f wav - | qaac64 --tvbr 91 --ignorelengt
 ```
 
 [itunes]: https://secure-appldnld.apple.com/itunes12/001-37026-20200915-5CBD39A0-F7A0-11EA-BB8F-8EB5DD073FF6/iTunes64Setup.exe
-[qaac]: https://sites.google.com/site/qaacpage/cabinet
+[qaac]: https://sites.google.com/site/qaacpage/
 [^1]: Read why in this [HydrogenAudio forum post](https://hydrogenaud.io/index.php/topic,85135.msg921707.html#msg921707).
 
 

--- a/src/encoding/codecs/x264.md
+++ b/src/encoding/codecs/x264.md
@@ -323,4 +323,4 @@ Coming Soon
 
 ---
 
-[^1]: Source: <http://www.mpeg.org/MPEG/DVD/Book_A/Specs.html>
+[^1]: Source: <https://web.archive.org/web/20190203114601/http://www.mpeg.org/MPEG/DVD/Book_A/Specs.html>

--- a/src/encoding/codecs/x265.md
+++ b/src/encoding/codecs/x265.md
@@ -332,4 +332,4 @@ Coming Soon.
 
 ---
 
-[^1]: Source: <http://www.mpeg.org/MPEG/DVD/Book_A/Specs.html>
+[^1]: Source: <https://web.archive.org/web/20190203114601/http://www.mpeg.org/MPEG/DVD/Book_A/Specs.html>

--- a/src/encoding/masking-limiting-etc.md
+++ b/src/encoding/masking-limiting-etc.md
@@ -81,7 +81,7 @@ $$
 \mathrm{output} = \mathrm{clip~a} \times (\mathit{max~value} - \mathrm{mask}) + \mathrm{clip~b}
 $$
 
-[std.MaskedMerge]: http://www.vapoursynth.com/doc/functions/maskedmerge.html
+[std.MaskedMerge]: https://www.vapoursynth.com/doc/functions/video/maskedmerge.html
 
 ---
 
@@ -129,7 +129,7 @@ which allow finer control over the structuring element.
 However, these functions are significantly slower than
 `std.Minimum` and `std.Maximum`.
 
-[std.Minimum/std.Maximum]: http://www.vapoursynth.com/doc/functions/minimum_maximum.html
+[std.Minimum/std.Maximum]: https://www.vapoursynth.com/doc/functions/video/minimum_maximum.html
 [Erosion]: https://en.wikipedia.org/wiki/Erosion_(morphology)
 [Dilation]: https://en.wikipedia.org/wiki/Dilation_(morphology)
 [structuring element]: https://en.wikipedia.org/wiki/Structuring_element
@@ -139,7 +139,7 @@ However, these functions are significantly slower than
 
 TODO
 
-[std.Inflate/std.Deflate]: http://www.vapoursynth.com/doc/functions/deflate_inflate.html
+[std.Inflate/std.Deflate]: https://www.vapoursynth.com/doc/functions/video/deflate_inflate.html
 
 
 #### [std.Binarize][]
@@ -157,7 +157,7 @@ mask.std.Binarize(24, v0=0, v1=255)
 For methods of creating mask clips,
 there are a few general categories…
 
-[std.Binarize]: http://www.vapoursynth.com/doc/functions/binarize.html
+[std.Binarize]: https://www.vapoursynth.com/doc/functions/video/binarize_binarizemask.html
 
 
 ### Line masks
@@ -431,8 +431,8 @@ noise = core.std.MakeDiff(src, smooth) # subtract filtered clip from source leav
 smooth = core.std.MakeDiff(src, noise) # subtract diff clip to prevent clipping (doesn't apply to 32 bit)
 ```
 
-[std.MakeDiff]: http://www.vapoursynth.com/doc/functions/makediff.html
-[std.MergeDiff]: http://www.vapoursynth.com/doc/functions/mergediff.html
+[std.MakeDiff]: https://www.vapoursynth.com/doc/functions/video/makediff.html
+[std.MergeDiff]: https://www.vapoursynth.com/doc/functions/video/mergediff.html
 
 #### [std.Merge][]
 
@@ -449,13 +449,13 @@ $$
 It can be used to perform
 a weighted average of two clips or planes.
 
-[std.Merge]: http://www.vapoursynth.com/doc/functions/merge.html
+[std.Merge]: https://www.vapoursynth.com/doc/functions/video/merge.html
 
 #### [std.Expr][]
 
 TODO
 
-[std.Expr]: http://www.vapoursynth.com/doc/functions/expr.html
+[std.Expr]: https://www.vapoursynth.com/doc/functions/video/expr.html
 
 
 #### [std.Lut][] and [std.Lut2][]
@@ -466,8 +466,8 @@ You can substitute a normal Python function for the RPN expression, though,
 so you may still find it easier.
 See link for usage information.
 
-[std.Lut]: http://www.vapoursynth.com/doc/functions/lut.html
-[std.Lut2]: http://www.vapoursynth.com/doc/functions/lut2.html
+[std.Lut]: https://www.vapoursynth.com/doc/functions/video/lut.html
+[std.Lut2]: https://www.vapoursynth.com/doc/functions/video/lut2.html
 
 
 ## Limiting

--- a/src/encoding/preparation.md
+++ b/src/encoding/preparation.md
@@ -113,9 +113,7 @@ community-created scripts and plugins
 can be installed to extend the functionality of the frameserver.
 These are usually more specific than the universally usable core plugins
 or they are collections of wrappers and functions.
-A (non-exhaustive) list of plugins and scripts is available in the
-[official documentation][vs-plugins].
-Additionally, an extensive database of VapourSynth plugins and scripts
+An extensive database of VapourSynth plugins and scripts
 is available at [VSDB][vsdb].
 VSDB also offers a GUI for [vsrepo][vsrepo],
 VapourSynth's official package manager,
@@ -130,7 +128,6 @@ on top of a broad collection of VapourSynth plugins and scripts.
 However, the package is not maintained anymore,
 and may in part include outdated software.
 
-[vs-plugins]: http://www.vapoursynth.com/doc/pluginlist.html "Plugins, Applications & Scripts"
 [vsdb]: http://vsdb.top/
 [vsrepo]: https://github.com/vapoursynth/vsrepo
 [ex-encode-pack]: https://iamscum.wordpress.com/encoding-stuff/encode-pack/
@@ -285,7 +282,7 @@ such as Intel's [SVT-AV1][] will also not be included.
 [tmod-git-releases]: https://github.com/jpsdr/x264/releases
 [Daala]: https://xiph.org/daala/
 [AV-1]: https://aomediacodec.github.io/av1-spec/
-[SVT-AV1]: https://github.com/OpenVisualCloud/SVT-AV1
+[SVT-AV1]: https://gitlab.com/AOMediaCodec/SVT-AV1
 [unification-commit]: https://code.videolan.org/videolan/x264/commit/71ed44c7
 
 
@@ -377,7 +374,7 @@ In short—don't bother,
 unless you really have to, for some reason.
 
 [FLAC]: https://xiph.org/flac/download.html
-[qaac]: https://sites.google.com/site/qaacpage/cabinet
+[qaac]: https://sites.google.com/site/qaacpage/
 [opus]: https://opus-codec.org/downloads/
 
 

--- a/src/encoding/video-artifacts.md
+++ b/src/encoding/video-artifacts.md
@@ -310,8 +310,8 @@ can be seen below.
 ![](images/overflow_notice.jpg)
 *When you see a histogram like this, increase precision.*
 
-[resize]: http://www.vapoursynth.com/doc/functions/resize.html
-[std-Levels]: http://www.vapoursynth.com/doc/functions/levels.html
+[resize]: https://www.vapoursynth.com/doc/functions/video/resize.html
+[std-Levels]: https://www.vapoursynth.com/doc/functions/video/levels.html
 
 ---
 


### PR DESCRIPTION
This required updating links to the new Vapoursynth documentation and
making a link to the DVD specification point to the Wayback Machine.

The link to http://maven.whatbox.ca:11665/resample_kernels/kernels.html
in resampling.md is dead too but wasn't replaced.

A sentence linking a list of plugins in the Vapoursynth docs was removed
since the list of plugins doesn't exist anymore.